### PR TITLE
feat(@typescript-eslint): disable @typescript-eslint/no-extra-parens

### DIFF
--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -4,6 +4,7 @@ module.exports = {
   rules: {
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/member-delimiter-style": "off",
-    "@typescript-eslint/type-annotation-spacing": "off"
+    "@typescript-eslint/type-annotation-spacing": "off",
+    "@typescript-eslint/no-extra-parens": "off"
   }
 };


### PR DESCRIPTION
The rule is conflicting with Prettier’s auto formatting